### PR TITLE
Add ability to load a project by name or "on" key

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,39 @@ For specific usage, please refer to [#5](https://github.com/MasouShizuka/project
 When enabled, notifications are displayed when actions are performed.
 
 `title`, `timeout`, `level` are the same as [ya.notify](https://yazi-rs.github.io/docs/plugins/utils/#ya.notify).
+
+### Optional configuration
+
+If you want to load a specific project with a keybinding (you can use either the key or the name of the project):
+
+```toml
+[[mgr.prepend_keymap]]
+on = [ "P", "p" ]
+run = "plugin projects 'load SomeProject'"
+desc = "Load the 'SomeProject' project"
+```
+
+You can also load a specific project by using the below Bash/Zsh function (uses the "official" [shell wrapper](https://yazi-rs.github.io/docs/quick-start/#shell-wrapper), but you can also replace `y` with `yazi`):
+
+```bash
+function yap() {
+    local yaziProject="$1"
+    shift
+    if [ -z "$yaziProject" ]; then
+        >&2 echo "ERROR: The first argument must be a project"
+        return 64
+    fi
+    
+    # Generate random Yazi client ID (DDS / `ya emit` uses `YAZI_ID`)
+    local yaziId=$RANDOM
+    
+    # Use Yazi's DDS to run a plugin command after Yazi has started
+    # (the nested subshell is only to suppress "Done" output for the job)
+    ( (sleep 0.1; YAZI_ID=$yaziId ya emit plugin projects "load $yaziProject") &)
+    
+    # Run Yazi with the generated client ID
+    y --client-id $yaziId "$@" || return $?
+}
+```
+
+With the above function you can open a specific project by running e.g. `yap SomeProject`

--- a/main.lua
+++ b/main.lua
@@ -930,7 +930,7 @@ local _merge_event = ya.sync(function(state)
     end)
 end)
 
-local _find_project_index = function(list, search_term)
+local _find_project_index = ya.sync(function(state, list, search_term)
     if not search_term then
         return nil
     end
@@ -943,7 +943,7 @@ local _find_project_index = function(list, search_term)
     end
 
     return nil
-end
+end)
 
 return {
     setup = function(_, opts)

--- a/main.lua
+++ b/main.lua
@@ -930,6 +930,21 @@ local _merge_event = ya.sync(function(state)
     end)
 end)
 
+local _find_project_index = function(list, search_term)
+    if not search_term then
+        return nil
+    end
+
+    for i, project in ipairs(list) do
+        -- Match the project by the "on" key or by "desc"
+        if project.on == search_term or project.desc == search_term then
+            return i
+        end
+    end
+
+    return nil
+end
+
 return {
     setup = function(_, opts)
         _load_config(opts)
@@ -1012,7 +1027,12 @@ return {
             return
         end
 
-        local selected_idx = ya.which({ cands = list, silent = false })
+        local selected_idx = (
+            -- Search for the project, if an argument was given
+            _find_project_index(list, job.args[2])
+            -- Ask interactively
+            or ya.which({ cands = list, silent = false })
+        )
         if not selected_idx then
             return
         end


### PR DESCRIPTION
The "load" action now accepts an argument, which is used to find a project by name/description or the "on" keyboard key.

This can be used to create a keybinding to load a specific project (here named "Default"):
```yaml
{ on = [ "P", "P"  ], run = "plugin projects 'load Default'", desc = "Load the 'Default'project"  },
```

It can also be used to start Yazi with a specific project using a script:
```bash
#!/bin/bash

#
# Open a project in Yazi.
#
# https://yazi-rs.github.io/docs/plugins/utils/#ya.emit
# https://github.com/MasouShizuka/projects.yazi
#

export yaziProject="$1"
shift

if [ -z "$yaziProject" ]; then
    >&2 echo "ERROR: The first argument must be a project"
    exit 64
fi

# Generate random Yazi client ID (DDS / `ya emit` uses `YAZI_ID`)
export YAZI_ID=$RANDOM

# Use Yazi's DDS to run a plugin command after Yazi has started
# (the nested subshell is only to suppress "Done" output for the job)
( (sleep 0.1; ya emit plugin projects "load $yaziProject") &)

# Run Yazi with the generated client ID
yazi --client-id $YAZI_ID "$@"
```